### PR TITLE
Add checks in toMsg and fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
              ROS_DISTRO: kinetic,
              ROS_REPO: main,
              UPSTREAM_WORKSPACE: 'github:swri-robotics/descartes_light#master github:Jmeyer1292/opw_kinematics#master github:ros-industrial-consortium/trajopt_ros#master github:ros-industrial-consortium/tesseract#master',
-             ROSDEP_SKIP_KEYS: "bullet3 fcl",
+             ROSDEP_SKIP_KEYS: "bullet3 fcl benchmark",
              DOCKER_IMAGE: "lharmstrong/tesseract:kinetic",
              CCACHE_DIR: "/home/runner/work/tesseract_ros/tesseract_ros/Xenial-Build/.ccache",
              UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release",

--- a/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/plotting.h
+++ b/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/plotting.h
@@ -277,8 +277,6 @@ public:
     collisions_pub_.publish(msg);
     arrows_pub_.publish(msg);
     axes_pub_.publish(msg);
-
-    ros::Duration(0.5).sleep();
   }
 
   void waitForInput() override

--- a/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
+++ b/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
@@ -1194,6 +1194,7 @@ inline void toMsg(trajectory_msgs::JointTrajectory& traj_msg,
     jtp.time_from_start = ros::Duration(i);
     traj_msg.points[static_cast<size_t>(i)] = jtp;
   }
+  std::size_t jn_to_index_size = jn_to_index.size();
 
   // Update only the joints which were provided.
   for (int i = 0; i < traj.rows(); ++i)
@@ -1204,6 +1205,9 @@ inline void toMsg(trajectory_msgs::JointTrajectory& traj_msg,
           .positions[static_cast<size_t>(jn_to_index[joint_names[static_cast<size_t>(j)]])] = traj(i, j);
     }
   }
+  // This will be the case if joint_names[static_cast<size_t>(j)] was not already in the map
+  if (jn_to_index_size != jn_to_index.size())
+    ROS_WARN("Trying to set joints that are not in the environment. Check that the joint_names are correct");
 }
 
 /**


### PR DESCRIPTION
If the joint_names vector you pass in has values that aren't in the environment (e.g. a typo), it can give unintuitive results as it just gets added to the map. This prints a warning if the map grows. Also fixes CI