### PR TITLE
Feature/optional environment

### DIFF
--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/launch/pick_and_place_example.launch
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/launch/pick_and_place_example.launch
@@ -22,13 +22,6 @@
     <param name="box_y" value="$(arg box_y)"/>
     <param name="box_parent_link" value="$(arg box_parent_link)"/>
     <group unless="$(arg testing)">
-
-      <!-- Launch GUI to drive joints   -->
-      <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-
-      <!-- Launch robot state publisher - may need to remap to /iiwa/joints..-->
-      <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
-
       <!-- Launch planner node -->
       <node name="tesseract_ros_examples_pick_and_place_example_node" pkg="tesseract_ros_examples" type="tesseract_ros_examples_pick_and_place_example_node" output="screen">
           <param name="steps_per_phase" value="$(arg steps_per_phase)"/>

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/basic_cartesian_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/basic_cartesian_example.cpp
@@ -221,7 +221,7 @@ bool BasicCartesianExample::run()
   }
 
   // Create plotting tool
-  ROSPlottingPtr plotter = std::make_shared<ROSPlotting>(tesseract_->getEnvironment());
+  ROSPlottingPtr plotter = std::make_shared<ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   // Set the robot initial state
   std::unordered_map<std::string, double> ipos;

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/car_seat_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/car_seat_example.cpp
@@ -336,7 +336,7 @@ bool CarSeatExample::run()
 
   // Create plotting tool
   tesseract_rosutils::ROSPlottingPtr plotter =
-      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment());
+      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   // Get predefined positions
   saved_positions_ = getPredefinedPosition();

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/freespace_ompl_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/freespace_ompl_example.cpp
@@ -71,7 +71,7 @@ bool FreespaceOMPLExample::run()
 
   // Create plotting tool
   tesseract_rosutils::ROSPlottingPtr plotter =
-      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment());
+      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   if (rviz_)
   {

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_upright_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_upright_example.cpp
@@ -175,7 +175,7 @@ bool GlassUprightExample::run()
 
   // Create plotting tool
   tesseract_rosutils::ROSPlottingPtr plotter =
-      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment());
+      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   if (rviz_)
   {

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_upright_ompl_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_upright_ompl_example.cpp
@@ -235,7 +235,7 @@ bool GlassUprightOMPLExample::run()
 
   // Create plotting tool
   tesseract_rosutils::ROSPlottingPtr plotter =
-      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment());
+      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   if (rviz_)
   {

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/online_planning_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/online_planning_example.cpp
@@ -80,7 +80,8 @@ OnlinePlanningExample::OnlinePlanningExample(const ros::NodeHandle& nh,
     assert(false);
 
   // Set up plotting
-  plotter_ = std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment());
+  plotter_ =
+      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   // Extract necessary kinematic information
   manipulator_fk_ = tesseract_->getFwdKinematicsManager()->getFwdKinematicSolver("manipulator");

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/pick_and_place_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/pick_and_place_example.cpp
@@ -87,7 +87,7 @@ bool PickAndPlaceExample::run()
 
   // Create plotting tool
   tesseract_rosutils::ROSPlottingPtr plotter =
-      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment());
+      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   if (rviz_)
   {

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_auxillary_axes_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_auxillary_axes_example.cpp
@@ -210,7 +210,7 @@ bool PuzzlePieceAuxillaryAxesExample::run()
     return false;
 
   // Create plotting tool
-  ROSPlottingPtr plotter = std::make_shared<ROSPlotting>(tesseract_->getEnvironment());
+  ROSPlottingPtr plotter = std::make_shared<ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   if (rviz_)
   {

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_example.cpp
@@ -225,7 +225,7 @@ bool PuzzlePieceExample::run()
 
   // Create plotting tool
   tesseract_rosutils::ROSPlottingPtr plotter =
-      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment());
+      std::make_shared<tesseract_rosutils::ROSPlotting>(tesseract_->getEnvironment()->getSceneGraph()->getRoot());
 
   // These are used to keep visualization updated
   if (rviz_)


### PR DESCRIPTION
This is a breaking change to the ROSPlotter to remove the necessity of using having access to the environment. This allows it to be used in place of moveit_visual_tools for example.