### PR TITLE
Remove joint state publisher from environment monitor launch file

### DIFF
--- a/tesseract_ros/tesseract_monitoring/launch/environment_monitor.launch
+++ b/tesseract_ros/tesseract_monitoring/launch/environment_monitor.launch
@@ -6,13 +6,6 @@
   <arg name="joint_state_topic" default=""/>
   <arg name="environment_topic" default=""/>
   <arg name="published_environment_topic" default=""/>
-  <arg name="rate" default="60"/>
-  <arg name="use_gui" default="false"/>
-
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="rate" value="$(arg rate)"/>
-    <param name="use_gui" value="$(arg use_gui)" />
-  </node>
 
   <node pkg="tesseract_monitoring" type="tesseract_monitoring_environment_node" name="tesseract_monitoring_environment">
     <param name="robot_description" type="string" value="$(arg robot_description)"/>
@@ -21,5 +14,4 @@
     <param name="environment_topic" type="string" value="$(arg environment_topic)"/>
     <param name="published_environment_topic" type="string" value="$(arg published_environment_topic)"/>
   </node>
-
 </launch>


### PR DESCRIPTION
The joint state publisher doesn't have much to do with the environment monitor, and systems may or may not need/want it.