### PR TITLE
Add option to start state monitor without publishing tf

### DIFF
--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
@@ -201,7 +201,7 @@ private:
   tf2_ros::TransformBroadcaster tf_broadcaster_;
   ros::Time current_state_time_;
   ros::Time last_tf_update_;
-  bool publish_tf_
+  bool publish_tf_;
 
   mutable std::mutex state_update_lock_;
   mutable std::condition_variable state_update_condition_;

--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
@@ -91,8 +91,10 @@ public:
 
   /** @brief Start monitoring joint states on a particular topic
    *  @param joint_states_topic The topic name for joint states (defaults to "joint_states")
+   *  @param publish_tf If true, TFs will be published for each joint (similar to robot description publisher). Default:
+   * true
    */
-  void startStateMonitor(const std::string& joint_states_topic = "joint_states");
+  void startStateMonitor(const std::string& joint_states_topic = "joint_states", bool publish_tf = true);
 
   /** @brief Stop monitoring the "joint_states" topic
    */
@@ -199,8 +201,9 @@ private:
   tf2_ros::TransformBroadcaster tf_broadcaster_;
   ros::Time current_state_time_;
   ros::Time last_tf_update_;
+  bool publish_tf_
 
-  mutable std::mutex state_update_lock_;
+      mutable std::mutex state_update_lock_;
   mutable std::condition_variable state_update_condition_;
   std::vector<JointStateUpdateCallback> update_callbacks_;
 };

--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
@@ -203,7 +203,7 @@ private:
   ros::Time last_tf_update_;
   bool publish_tf_
 
-      mutable std::mutex state_update_lock_;
+  mutable std::mutex state_update_lock_;
   mutable std::condition_variable state_update_condition_;
   std::vector<JointStateUpdateCallback> update_callbacks_;
 };

--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/environment_monitor.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/environment_monitor.h
@@ -263,8 +263,9 @@ public:
 
   /** @brief Start the current state monitor
       @param joint_states_topic the topic to listen to for joint states
-      @param attached_objects_topic the topic to listen to for attached collision objects */
-  void startStateMonitor(const std::string& joint_states_topic = DEFAULT_JOINT_STATES_TOPIC);
+      @param publish_tf If true, TFs will be published for each joint (similar to robot description publisher). Default:
+     true  */
+  void startStateMonitor(const std::string& joint_states_topic = DEFAULT_JOINT_STATES_TOPIC, bool publish_tf = true);
 
   /** @brief Stop the state monitor*/
   void stopStateMonitor();

--- a/tesseract_ros/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/environment_monitor.cpp
@@ -655,7 +655,7 @@ std::unique_lock<std::shared_mutex> EnvironmentMonitor::lockEnvironmentWrite()
   return std::unique_lock(scene_update_mutex_);
 }
 
-void EnvironmentMonitor::startStateMonitor(const std::string& joint_states_topic)
+void EnvironmentMonitor::startStateMonitor(const std::string& joint_states_topic, bool publish_tf)
 {
   stopStateMonitor();
   if (tesseract_->getEnvironment())
@@ -665,7 +665,7 @@ void EnvironmentMonitor::startStateMonitor(const std::string& joint_states_topic
           new CurrentStateMonitor(tesseract_->getEnvironment(), tesseract_->getManipulatorManager(), root_nh_));
 
     current_state_monitor_->addUpdateCallback(boost::bind(&EnvironmentMonitor::onJointStateUpdate, this, _1));
-    current_state_monitor_->startStateMonitor(joint_states_topic);
+    current_state_monitor_->startStateMonitor(joint_states_topic, publish_tf);
 
     {
       std::scoped_lock lock(state_pending_mutex_);


### PR DESCRIPTION
This allows multiple things to be tracking the state but only one to be publishing TFs