### PR TITLE
Fix tesseract_monitoring recursive mutex and tesseract_monitor setting id

### DIFF
--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/tesseract_monitor_interface.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/tesseract_monitor_interface.h
@@ -58,7 +58,7 @@ public:
    */
   static const std::string DEFAULT_MODIFY_ENVIRONMENT_SERVICE;
 
-  TesseractMonitorInterface() = default;
+  TesseractMonitorInterface(const std::string& env_name);
   virtual ~TesseractMonitorInterface() = default;
   TesseractMonitorInterface(const TesseractMonitorInterface&) = default;
   TesseractMonitorInterface& operator=(const TesseractMonitorInterface&) = default;
@@ -199,6 +199,7 @@ public:
 protected:
   ros::NodeHandle nh_;
   std::vector<std::string> ns_;
+  std::string env_name_;
 
   bool sendCommands(const std::string& ns, const std::vector<tesseract_msgs::EnvironmentCommand>& commands) const;
 };

--- a/tesseract_ros/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/environment_monitor.cpp
@@ -473,7 +473,7 @@ void EnvironmentMonitor::newTesseractStateCallback(const tesseract_msgs::Tessera
       res.request.revision = static_cast<unsigned long>(environment->getRevision());
       if (get_monitored_environment_changes_client_.call(res))
       {
-        if (!applyEnvironmentCommandsMessage(res.response.id, environment->getRevision(), res.response.commands))
+        if (!tesseract_rosutils::processMsg(*(tesseract_->getEnvironment()), res.response.commands))
         {
           ROS_ERROR_STREAM_NAMED(monitor_namespace_, "Failed to apply monitored environments changes.");
         }
@@ -497,7 +497,7 @@ void EnvironmentMonitor::newTesseractStateCallback(const tesseract_msgs::Tessera
             res.request.revision = static_cast<unsigned long>(environment->getRevision());
             if (get_monitored_environment_changes_client_.call(res))
             {
-              if (!applyEnvironmentCommandsMessage(res.response.id, environment->getRevision(), res.response.commands))
+              if (!tesseract_rosutils::processMsg(*(tesseract_->getEnvironment()), res.response.commands))
               {
                 ROS_ERROR_STREAM_NAMED(monitor_namespace_, "Failed to apply monitored environments changes.");
               }

--- a/tesseract_ros/tesseract_monitoring/src/tesseract_monitor_interface.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/tesseract_monitor_interface.cpp
@@ -38,6 +38,8 @@ const std::string TesseractMonitorInterface::DEFAULT_GET_ENVIRONMENT_INFORMATION
     R"(/get_tesseract_information)";
 const std::string TesseractMonitorInterface::DEFAULT_MODIFY_ENVIRONMENT_SERVICE = R"(/modify_tesseract)";
 
+TesseractMonitorInterface::TesseractMonitorInterface(const std::string& env_name) : env_name_(env_name) {}
+
 void TesseractMonitorInterface::addNamespace(std::string monitor_namespace)
 {
   if (std::find(ns_.begin(), ns_.end(), monitor_namespace) == ns_.end())
@@ -144,7 +146,7 @@ bool TesseractMonitorInterface::sendCommands(const std::string& ns,
                                              const std::vector<tesseract_msgs::EnvironmentCommand>& commands) const
 {
   tesseract_msgs::ModifyEnvironment res;
-  res.request.id = ns;
+  res.request.id = env_name_;
   res.request.append = true;
   res.request.commands = commands;
 
@@ -177,16 +179,6 @@ TesseractMonitorInterface::getEnvironmentState(const std::string& monitor_namesp
   tesseract_rosutils::fromMsg(env_state->joints, res.response.joint_states);
   tesseract_rosutils::fromMsg(env_state->link_transforms, res.response.link_transforms);
   tesseract_rosutils::fromMsg(env_state->joint_transforms, res.response.joint_transforms);
-  //  tesseract_environment::Commands commands;
-  //  try
-  //  {
-  //    commands = tesseract_rosutils::fromMsg(res.response.command_history);
-  //  }
-  //  catch (...)
-  //  {
-  //    ROS_ERROR_STREAM_NAMED(monitor_namespace, "Failed to convert command history message!");
-  //    return nullptr;
-  //  }
 
   return env_state;
 }

--- a/tesseract_ros/tesseract_planning_server/src/tesseract_planning_server.cpp
+++ b/tesseract_ros/tesseract_planning_server/src/tesseract_planning_server.cpp
@@ -92,6 +92,7 @@ const tesseract_monitoring::EnvironmentMonitor& TesseractPlanningServer::getEnvi
 
 void TesseractPlanningServer::onMotionPlanningCallback(const tesseract_msgs::GetMotionPlanGoalConstPtr& goal)
 {
+  ROS_INFO("Tesseract Planning Server Recieved Request!");
   tesseract_planning::Instruction program = tesseract_planning::fromXMLString(goal->request.instructions);
   const auto* composite_program = program.cast_const<tesseract_planning::CompositeInstruction>();
 
@@ -312,6 +313,7 @@ void TesseractPlanningServer::onMotionPlanningCallback(const tesseract_msgs::Get
     }
   }
 
+  ROS_INFO("Tesseract Planning Server Finished Request!");
   motion_plan_server_.setSucceeded(result);
 }
 


### PR DESCRIPTION
During testing I ran into a dead lock with the mutex. The function was taking a lock on the shared mutex and then called another function which tries to take the lock. After looking at what each function was doing I was able two switch out the function call with the single call to the processMsg function to solve the issue.

In addition, The tesseract monitor interface class need the environment name which is used to confirm that the intended commands id matches the environment name.