### PR TITLE
Command in Planning Request and Tesseract Caching 

### DIFF
--- a/tesseract_ros/tesseract_msgs/msg/PlanningRequest.msg
+++ b/tesseract_ros/tesseract_msgs/msg/PlanningRequest.msg
@@ -1,4 +1,5 @@
 tesseract_msgs/TesseractState tesseract_state
+tesseract_msgs/EnvironmentCommand[] commands # Additional Commands to be applied to environment prior to planning
 
 string name # The name of the planner to use
 string instructions # This should an xml string of the command language instructions

--- a/tesseract_ros/tesseract_planning_server/CMakeLists.txt
+++ b/tesseract_ros/tesseract_planning_server/CMakeLists.txt
@@ -4,6 +4,7 @@ project(tesseract_planning_server)
 find_package(catkin REQUIRED COMPONENTS
   tesseract_monitoring
   tesseract_msgs
+  tesseract_rosutils
   tf2_ros
   tf2_eigen
 )
@@ -23,6 +24,7 @@ catkin_package(
   CATKIN_DEPENDS
     tesseract_msgs
     tesseract_monitoring
+    tesseract_rosutils
     tf2_ros
     tf2_eigen
   DEPENDS

--- a/tesseract_ros/tesseract_planning_server/launch/planning_server.launch
+++ b/tesseract_ros/tesseract_planning_server/launch/planning_server.launch
@@ -6,6 +6,8 @@
   <arg name="discrete_plugin" default="BulletDiscreteBVHManager"/>
   <arg name="continuous_plugin" default="BulletCastBVHManager"/>
   <arg name="publish_environment" default="false"/>
+  <arg name="cache_size" default="5"/>
+  <arg name="cache_refresh_rate" default="0.1"/>
 
   <node pkg="tesseract_planning_server" type="tesseract_planning_server_node" name="tesseract_planning_server">
     <param name="robot_description" type="string" value="$(arg robot_description)"/>
@@ -14,6 +16,8 @@
     <param name="monitor_namespace" type="string" value="$(arg monitor_namespace)"/>
     <param name="monitored_namespace" type="string" value="$(arg monitored_namespace)"/>
     <param name="publish_environment" type="bool" value="$(arg publish_environment)"/>
+    <param name="cache_size" type="int" value="$(arg cache_size)"/>
+    <param name="cache_refresh_rate" type="double" value="$(arg cache_refresh_rate)"/>
   </node>
 
 </launch>

--- a/tesseract_ros/tesseract_planning_server/package.xml
+++ b/tesseract_ros/tesseract_planning_server/package.xml
@@ -16,6 +16,7 @@
   <depend>tesseract_command_language</depend>
   <depend>tesseract_process_managers</depend>
   <depend>tesseract_motion_planners</depend>
+  <depend>tesseract_rosutils</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_eigen</depend>
 

--- a/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
+++ b/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
@@ -232,11 +232,16 @@ void toMsg(trajectory_msgs::JointTrajectory& traj_msg, const tesseract_common::J
 void toMsg(const trajectory_msgs::JointTrajectoryPtr& traj_msg, const tesseract_common::JointTrajectory& traj);
 
 bool processMsg(tesseract_environment::Environment& env, const sensor_msgs::JointState& joint_state_msg);
+bool processMsg(const tesseract_environment::Environment::Ptr& env, const sensor_msgs::JointState& joint_state_msg);
 
+/**
+ * @brief Apply the provided commands to the environment
+ * @param env The environment to apply the commands
+ * @param env_command_msg The commands to apply
+ * @return True if successful, otherwise false
+ */
 bool processMsg(tesseract_environment::Environment& env,
                 const std::vector<tesseract_msgs::EnvironmentCommand>& env_command_msg);
-
-bool processMsg(const tesseract_environment::Environment::Ptr& env, const sensor_msgs::JointState& joint_state_msg);
 
 /**
  * @brief Convert Geometry Pose Message to Eigen


### PR DESCRIPTION
This add the ability to add addition commands to be applied to the environment prior to motion planning. This is useful for planning multiple scenarios at the same time without having to modify the main environment. It also creates a cache of Tesseract Objects which gets maintained to speed up motion request.