### PR TITLE
Fix waitForConnection and Planning Server cache refresh

### DIFF
--- a/tesseract_ros/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/environment_monitor.cpp
@@ -132,6 +132,7 @@ bool EnvironmentMonitor::waitForConnection(ros::Duration timeout) const
     }
 
     ros::WallDuration(0.02).sleep();
+    ros::spinOnce();
   }
 
   return false;

--- a/tesseract_ros/tesseract_planning_server/src/tesseract_planning_server.cpp
+++ b/tesseract_ros/tesseract_planning_server/src/tesseract_planning_server.cpp
@@ -132,7 +132,7 @@ void TesseractPlanningServer::refreshCache()
   else if (cache_.size() <= 2)
   {
     for (std::size_t i = (cache_.size() - 1); i < cache_size_; ++i)
-      cache_.push_back(thor->clone());
+      cache_.push_back(cache_.front()->clone());
   }
 }
 

--- a/tesseract_ros/tesseract_rosutils/src/plotting.cpp
+++ b/tesseract_ros/tesseract_rosutils/src/plotting.cpp
@@ -79,6 +79,7 @@ void ROSPlotting::waitForConnection(long seconds) const
     }
 
     ros::WallDuration(0.02).sleep();
+    ros::spinOnce();
   }
 
   return;


### PR DESCRIPTION
Since the waitForConnection does not call spinOnce it was not processing other callbacks not allowing it to work properly.
The second item was the cache refresh was not working correctly because it was accessing a nullptr.