### PR TITLE
Add missing dependency to tesseract_rosutils

### DIFF
--- a/tesseract_ros/tesseract_rosutils/CMakeLists.txt
+++ b/tesseract_ros/tesseract_rosutils/CMakeLists.txt
@@ -11,14 +11,15 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Boost REQUIRED)
+find_package(cmake_common_scripts REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(tesseract_scene_graph REQUIRED)
-find_package(tesseract_geometry REQUIRED) # This should not be required, must be doing something wrong when creating targets
-find_package(tesseract_visualization REQUIRED)
 find_package(tesseract_collision REQUIRED)
 find_package(tesseract_common REQUIRED)
+find_package(tesseract_environment REQUIRED)
+find_package(tesseract_geometry REQUIRED) # This should not be required, must be doing something wrong when creating targets
 find_package(tesseract_motion_planners REQUIRED)
-find_package(cmake_common_scripts REQUIRED)
+find_package(tesseract_scene_graph REQUIRED)
+find_package(tesseract_visualization REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS
@@ -48,7 +49,16 @@ catkin_package(
 tesseract_variables()
 
 add_library(${PROJECT_NAME} SHARED src/plotting.cpp src/conversions.cpp src/utils.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC tesseract::tesseract_scene_graph tesseract::tesseract_geometry tesseract::tesseract_collision_core tesseract::tesseract_visualization tesseract::tesseract_common tesseract::tesseract_motion_planners_core ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  tesseract::tesseract_collision_core
+  tesseract::tesseract_common
+  tesseract::tesseract_environment_core
+  tesseract::tesseract_geometry
+  tesseract::tesseract_motion_planners_core
+  tesseract::tesseract_scene_graph
+  tesseract::tesseract_visualization
+  ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES})
 target_compile_options(${PROJECT_NAME} PRIVATE ${TESSERACT_COMPILE_OPTIONS})
 target_clang_tidy(${PROJECT_NAME} ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME} PUBLIC VERSION 14)

--- a/tesseract_ros/tesseract_rosutils/package.xml
+++ b/tesseract_ros/tesseract_rosutils/package.xml
@@ -11,12 +11,13 @@
   <build_depend>cmake_common_scripts</build_depend>
 
   <depend>tesseract_collision</depend>
+  <depend>tesseract_common</depend>
+  <depend>tesseract_environment</depend>
+  <depend>tesseract_geometry</depend>
+  <depend>tesseract_motion_planners</depend>
   <depend>tesseract_msgs</depend>
   <depend>tesseract_scene_graph</depend>
-  <depend>tesseract_geometry</depend>
   <depend>tesseract_visualization</depend>
-  <depend>tesseract_common</depend>
-  <depend>tesseract_motion_planners</depend>
 
   <build_depend>eigen</build_depend>
   <build_export_depend>eigen</build_export_depend>


### PR DESCRIPTION
I also rearranged them to be in alphabetical order, but the only one I added was tesseract::tesseract_environment::core