### PR TITLE
Update catkin dependencies

### DIFF
--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/CMakeLists.txt
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/CMakeLists.txt
@@ -263,9 +263,7 @@ target_include_directories(${PROJECT_NAME}_scene_graph_example_node SYSTEM PRIVA
 # Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}
   DESTINATION include
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
- )
+)
 
 # Mark executables and/or libraries for installation
 install(

--- a/tesseract_ros/tesseract_monitoring/CMakeLists.txt
+++ b/tesseract_ros/tesseract_monitoring/CMakeLists.txt
@@ -37,10 +37,7 @@ catkin_package(
     tf2_eigen
     visualization_msgs
   DEPENDS
-    EIGEN3
-    tesseract
     orocos_kdl
-    tesseract_common
 )
 
 include_directories(
@@ -96,9 +93,7 @@ install(TARGETS ${PROJECT_NAME}_environment ${PROJECT_NAME}_contacts ${PROJECT_N
 # Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
- )
+)
 
 install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/tesseract_ros/tesseract_monitoring/cmake/tesseract_monitoring-extras.cmake
+++ b/tesseract_ros/tesseract_monitoring/cmake/tesseract_monitoring-extras.cmake
@@ -1,0 +1,2 @@
+find_package(tesseract REQUIRED)
+find_package(tesseract_common REQUIRED)

--- a/tesseract_ros/tesseract_plugins/CMakeLists.txt
+++ b/tesseract_ros/tesseract_plugins/CMakeLists.txt
@@ -21,10 +21,8 @@ catkin_package(
     roscpp
     eigen_conversions
     pluginlib
-  DEPENDS
-    EIGEN3
-    tesseract_collision
-    tesseract_common
+  CFG_EXTRAS
+    ${PROJECT_NAME}-extras.cmake
 )
 
 add_library(tesseract_collision_bullet_plugin src/plugins/bullet_plugin.cpp)

--- a/tesseract_ros/tesseract_plugins/cmake/tesseract_plugins-extras.cmake
+++ b/tesseract_ros/tesseract_plugins/cmake/tesseract_plugins-extras.cmake
@@ -1,0 +1,2 @@
+find_package(tesseract REQUIRED)
+find_package(tesseract_common REQUIRED)

--- a/tesseract_ros/tesseract_rosutils/CMakeLists.txt
+++ b/tesseract_ros/tesseract_rosutils/CMakeLists.txt
@@ -20,12 +20,10 @@ find_package(tesseract_common REQUIRED)
 find_package(tesseract_motion_planners REQUIRED)
 find_package(tesseract_process_planners REQUIRED)
 
-
 catkin_package(
   INCLUDE_DIRS
     include
     ${EIGEN3_INCLUDE_DIRS}
-#  LIBRARIES
   CATKIN_DEPENDS
     tesseract_msgs
     roscpp
@@ -35,14 +33,8 @@ catkin_package(
     std_msgs
   DEPENDS
     Boost
-    EIGEN3
-    tesseract_scene_graph
-    tesseract_geometry
-    tesseract_visualization
-    tesseract_collision
-    tesseract_common
-    tesseract_process_planners
-    tesseract_motion_planners
+  CFG_EXTRAS
+    ${PROJECT_NAME}-extras.cmake
 )
 
 add_library(${PROJECT_NAME} INTERFACE)
@@ -67,9 +59,7 @@ install(
 # Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
- )
+)
 
 if(CATKIN_ENABLE_TESTING)
   find_package(GTest REQUIRED)

--- a/tesseract_ros/tesseract_rosutils/cmake/tesseract_rosutils-extras.cmake
+++ b/tesseract_ros/tesseract_rosutils/cmake/tesseract_rosutils-extras.cmake
@@ -1,0 +1,7 @@
+find_package(tesseract_scene_graph REQUIRED)
+find_package(tesseract_geometry REQUIRED) # This should not be required, must be doing something wrong when creating targets
+find_package(tesseract_visualization REQUIRED)
+find_package(tesseract_collision REQUIRED)
+find_package(tesseract_common REQUIRED)
+find_package(tesseract_motion_planners REQUIRED)
+find_package(tesseract_process_planners REQUIRED)

--- a/tesseract_ros/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_ros/tesseract_rviz/CMakeLists.txt
@@ -69,8 +69,8 @@ catkin_package(
     Boost
     OGRE
     QT
-    tesseract
-    tesseract_common
+  CFG_EXTRAS
+    ${PROJECT_NAME}-extras.cmake
 )
 
 include_directories(
@@ -289,8 +289,6 @@ install(TARGETS ${PROJECT_NAME}_render_tools ${PROJECT_NAME}_state_plugin_core $
 # Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
 )
 
 # Mark plugin XML files for installation

--- a/tesseract_ros/tesseract_rviz/cmake/tesseract_rviz-extras.cmake
+++ b/tesseract_ros/tesseract_rviz/cmake/tesseract_rviz-extras.cmake
@@ -1,0 +1,2 @@
+find_package(tesseract REQUIRED)
+find_package(tesseract_common REQUIRED)


### PR DESCRIPTION
This PR changes the `catkin_package` macro of the `tesseract_ros` packages to specify `tesseract` dependencies in the `CFG_EXTRAS` tag rather than `DEPENDS` tag. For packages added to the `DEPENDS` tag, catkin appends the output of the variable `<package_name>_LIBRARIES` to the variable `catkin_LIBRARIES`. Packages currently in `tesseract` only define a `<package_name>_LIBRARY_DIRS` variable, not a `_LIBRARIES` variable; thus adding them to the `DEPENDS` tag does nothing. Since `tesseract` uses modern CMake, it makes more sense to specify these dependencies in `CFG_EXTRAS`