### PR TITLE
Change Descartes-Light dependency to an older version to fix Tesseract-Planning build problem

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -17,7 +17,7 @@
 - git:
     local-name: descartes_light
     uri: https://github.com/swri-robotics/descartes_light.git
-    version: master
+    version: 0.2.1
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git

--- a/dependencies_with_ext.rosinstall
+++ b/dependencies_with_ext.rosinstall
@@ -21,7 +21,7 @@
 - git:
     local-name: descartes_light
     uri: https://github.com/swri-robotics/descartes_light.git
-    version: master
+    version: 0.2.1 
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git


### PR DESCRIPTION
This fixed the build problems on Focal and Bionic on my system. Opening a pull request to see if it passes the CI.